### PR TITLE
- updated dependencies (PHP)

### DIFF
--- a/debian/liveconfig-meta-nginx/DEBIAN/control
+++ b/debian/liveconfig-meta-nginx/DEBIAN/control
@@ -1,15 +1,16 @@
 Package: liveconfig-meta-nginx
-Version: 0.4.1
+Version: 0.4.2
 Section: net
 Priority: optional
 Architecture: all
 Essential: no
-Depends: quota, bzip2, unzip, zip,
+Depends: libc6 (>= 2.13), ca-certificates, quota, bzip2, unzip, zip,
  nginx,
- php5-cli, php5-cgi, php5-curl, php5-gd, php5-imagick, php5-imap, php5-mcrypt, php5-mhash, php5-mysql, php5-sqlite,
- imagemagick, postfix, dovecot-imapd, dovecot-pop3d, clamav-milter,
- mysql-server, proftpd-basic, webalizer
-Recommends: php5-suhosin, dovecot-sieve
+ php5-cgi | php-cgi, php5-cli | php-cli, php5-curl | php-curl, php5-gd | php-gd, php5-imagick | php-imagick,
+ php5-imap | php-imap, php5-mcrypt | php-mcrypt, php5-mysql | php-mysql, php5-sqlite | php-sqlite3,
+ imagemagick, postfix, dovecot-imapd, dovecot-pop3d, dovecot-sieve, clamav-milter, opendkim,
+ mysql-server | mariadb-server, proftpd-basic, webalizer
+Recommends: php5-suhosin | php-suhosin
 Installed-Size:
 Maintainer: Keppler IT GmbH <info@liveconfig.com>
 Homepage: http://www.liveconfig.com


### PR DESCRIPTION
- removed dovecot-sieve from recommends, as now a dependency
- increased Version to 0.4.2
- tested on Debian Stretch, should work on any supported Debian release